### PR TITLE
Fixed addons bug

### DIFF
--- a/src/components/Form/index.tsx
+++ b/src/components/Form/index.tsx
@@ -70,7 +70,8 @@ export function Form({ id, legend, description, children }: FormType) {
           dispatcher({ type: STEP_3, payload: { addOns: [] } });
           break;
         }
-        const addOnsList = addOns.map((addOn, index) => ({ name: addOn, price: CHECKBOX_LIST(globalState.planType)[index].price }));
+        const addOnsTemplate = CHECKBOX_LIST(globalState.planType);
+        const addOnsList = addOns.map((addOn) => ({ name: addOn, price: addOnsTemplate.find((item) => item.label === addOn)!.price }));
 
         dispatcher({ type: STEP_3, payload: { addOns: addOnsList } });
         break;


### PR DESCRIPTION
# PULL REQUEST 📋

## ▶ Descripción

> Solucionado bug que hacia que al agregar un addon (el segundo o el tercero), en la vista de checkout apareciera un precio incorrecto (10 en lugar de 20 / 1 en lugar de 2, dependiendo del tipo de plan).

## ▶ Información para el Reviewer

> Agregar cualquier cantidad de addons.

## 🔑 Datos de usuario para probar el cambio:

| UserID | Username | Password | SiteID |
| ------ | -------- | -------- | ------ |
|        |          |          |        |
|        |          |          |        |
|        |          |          |        |
|        |          |          |        |

## 🏷 Tipo de PR

- [X] :bug: Bugfix.
- [ ] :sparkles: Feature.
- [ ] :recycle: Refactoring.
- [ ] ⬆️ Update de dependencias.
- [ ] 🤷‍♂️ Otro (describir).
